### PR TITLE
Adjust some metadata field names to only letters/numbers/underscores

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -102,12 +102,12 @@ prose:
             element: text
             label: "Calculations"
             scope: national
-      - name: "Data Disaggregation Categories"
+      - name: "disaggregation_categories"
         field:
             element: text
             label: "Disaggregation Categories"
             scope: national
-      - name: "WCCD / International Organization for Standardization (ISO) 37120 Alignment"
+      - name: "wccd_iso_37120"
         field:
             element: text
             label: "WCCD/ISO 37120 Indicators on City Data Alignment"

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -38,7 +38,7 @@ source_active_6: false
 source_url_text_6: Link to source
 title: Untitled
 national_geographical_coverage: City of Los Angeles
-Data Disaggregation Categories: Park Agencies for years 2013 - 2016
+disaggregation_categories: Park Agencies for years 2013 - 2016
 source_organisation_1: The Trust for Public Land
 source_geographical_coverage_1: City of Los Angeles
 source_url_1: >-

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -49,7 +49,7 @@ source_organisation_2: World Council on City Data
 source_periodicity_2: Annual
 source_geographical_coverage_2: City of Los Angeles
 source_url_2: 'http://open.dataforcities.org'
-WCCD / International Organization for Standardization (ISO) 37120 Alignment: >-
+wccd_iso_37120: >-
   Aligns to WCCD/ISO 37120 11.2 - Women as Percentage of Total Elected to
   City-Level Office
 ---

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -38,7 +38,7 @@ source_url_text_5: Link to source
 source_active_6: false
 source_url_text_6: Link to source
 title: Untitled
-WCCD / International Organization for Standardization (ISO) 37120 Alignment: Aligns to WCCD 12.3 - Number of Physicians per 100k population
+wccd_iso_37120: Aligns to WCCD 12.3 - Number of Physicians per 100k population
 source_organisation_1: World Council on City Data
 source_geographical_coverage_1: City of Los Angeles
 source_url_1: open.dataforcities.org


### PR DESCRIPTION
I don't know for sure that this is necessary, but has been the general standard approach so far, so might be a good convention to maintain: only lowercase letters, numbers, and underscores for the field names.