### PR TITLE
Remove extra metadata section

### DIFF
--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -59,25 +59,3 @@ source_url_1: 'http://open.dataforcities.org/'
 source_organisation_1: World Council on City Data
 source_geographical_coverage_1: City of Los Angeles
 ---
-goal_meta_link_text: UN metadata
-reporting_status: complete
-data_non_statistical: false
-data_show_map: false
-graph_type: line
-source_active_1: true
-source_url_text_1: Link to source
-source_active_2: false
-source_url_text_2: Link to Source
-source_active_3: false
-source_url_3: Link to source
-source_active_4: false
-source_url_text_4: Link to source
-source_active_5: false
-source_url_text_5: Link to source
-source_active_6: false
-source_url_text_6: Link to source
-published: false
-title: Untitled
-tags:
-  - Revised
----


### PR DESCRIPTION
Somehow this indicator got an extra metadata section. Anything below the second "---" shows up as a paragraph at the top of the indicator.